### PR TITLE
fix: don't use ssh address for github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To install and run the XMTP Quickstart React App, you must have the following pr
 For example, run:
 
 ```bash
-git clone git@github.com:xmtp/xmtp-quickstart-react.git
+git clone https://github.com/xmtp/xmtp-quickstart-react.git
 ```
 
 ## Install the app


### PR DESCRIPTION
Prevents error such as this for non-associated users:

```
Cloning into 'xmtp-quickstart-react'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```