### PR TITLE
fix: prevent error from undefined convo messages

### DIFF
--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -8,7 +8,7 @@ const MessageList = ({ isNewMsg, convoMessages, selectedConvo }) => {
   return (
     <div className="msgs-container flex flex-dir-col">
       <div className="mt-auto">
-        {!isNewMsg &&
+        {!isNewMsg && convoMessages &&
           convoMessages.map((msg) => {
             return <MessageCard key={msg.id} msg={msg} />;
           })}


### PR DESCRIPTION
For new users, convo messages may be undefined. This PR prevents the app from crashing due to JS error.